### PR TITLE
Flipped the input order to the score calculation function

### DIFF
--- a/main/train_classifier_g.py
+++ b/main/train_classifier_g.py
@@ -3,7 +3,8 @@ from src import download_data
 download_data.download_data()
 
 import logging
-logging.basicConfig(filename="main/train_classifier.log", level=logging.INFO)
+logging.basicConfig(
+    filename="main/train_classifier.log", filemode="w", level=logging.INFO)
 logging.basicConfig(level=logging.INFO)
 from src import receive_data
 from src import classifiers
@@ -13,7 +14,7 @@ import pickle
 
 
 # train the classifier using the result of a SQL query
-def train_model(training_data, testing_data):
+def train_model(training_data, unlabeled_data):
   s = suite.Suite()
 
   logging.info("Loading data.")
@@ -22,7 +23,7 @@ def train_model(training_data, testing_data):
   s.set_train_set(training_data)
 
   # 2 columns: _id, text
-  s.set_unlabeled_set(testing_data)
+  s.set_unlabeled_set(unlabeled_data)
 
   # select model
   s.set_model(classifiers.svm_model)
@@ -47,5 +48,5 @@ def train_model(training_data, testing_data):
   result.to_csv("PATH_TO_OUTPUT_FILE", index=False)
 
 
-[training, testing] = receive_data.receive_data()
-train_model(training, testing)
+[training, unlabeled] = receive_data.receive_data()
+train_model(training, unlabeled)

--- a/src/create_features.py
+++ b/src/create_features.py
@@ -1,7 +1,6 @@
 # input: a pandas dataframe
 # output: a pandas dataframe
 
-import numpy as np
 from nltk.stem import WordNetLemmatizer
 from src import convo_politeness
 from src import text_cleaning

--- a/src/create_features.py
+++ b/src/create_features.py
@@ -1,6 +1,7 @@
 # input: a pandas dataframe
 # output: a pandas dataframe
 
+import numpy as np
 from nltk.stem import WordNetLemmatizer
 from src import convo_politeness
 from src import text_cleaning
@@ -8,12 +9,14 @@ from src import text_parser
 from src import util
 from src import config
 import json
+import logging
 import multiprocessing as mp
 import pandas as pd
 import re
 import requests
 import spacy
 import sys
+import time
 wordnet_lemmatizer = WordNetLemmatizer()
 nlp = spacy.load("en_core_web_md", disable = ["parser", "ner"])
 
@@ -111,7 +114,7 @@ def extract_features(total_comment_info):
 
 # input: pd.DataFrame
 # output: pd.DataFrame
-def create_features(comments_df):
+def create_features(comments_df, training):
   # remove invalide toxicity scores or empty comments
   comments_df = comments_df.dropna()
 
@@ -131,7 +134,7 @@ def create_features(comments_df):
   pool.close()
   features_df = pd.DataFrame(features)
   features_df = features_df.loc[features_df["perspective_score"] >= 0]
-  print("Total number of training data: {}.".format(len(comments_df)))
+  logging.info("Total number of {} data: {}.".format(training, len(comments_df)))
 
   #features_df.to_csv("training_data_label_cleaned.csv", index=False)
   return features_df


### PR DESCRIPTION
#27 

The problem was, the old code used its own function to calculate precision scores; when I replaced the function name with the standard function, I forgot to flip the order of the inputs (it used to be <prediction, truth>, while it should be <truth, prediction>). This means that the `support` column, while it's supposed to show the number of data points of each label in the training dataset, shows the number of data points predicted to be each label instead. When we saw a row of 0's in the second row of the matrix (label 1), it actually meant the model predicted 0 for all data (no label 1 in the prediction). 