### PR TITLE
Adding missing deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ pandas
 plac
 plac
 preshed
+python-dateutil
 pytz
 requests
 scipy

--- a/src/BUILD
+++ b/src/BUILD
@@ -78,6 +78,7 @@ py_binary(
         requirement("ftfy"),
         requirement("importlib_metadata"),
         requirement("kiwisolver"),
+        requirement("markdown"),
         requirement("murmurhash"),
         requirement("numpy"),
         requirement("pandas"),

--- a/src/BUILD
+++ b/src/BUILD
@@ -19,6 +19,9 @@ py_library(
 py_library(
     name = "download_data",
     srcs = ["download_data.py"],
+    deps = [
+        requirement("numpy"),
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -63,6 +66,7 @@ py_binary(
     name = "convo_word_freq_diff",
     srcs = ["convo_word_freq_diff.py"],
     visibility = ["//visibility:public"],
+    data = ["data/both_t_data.csv"],
     deps = [
         ":download_data",
         ":receive_data",
@@ -79,6 +83,7 @@ py_binary(
         requirement("pandas"),
         requirement("plac"),
         requirement("preshed"),
+        requirement("python-dateutil"),
         requirement("pytz"),
         requirement("spacy"),
         requirement("srsly"),


### PR DESCRIPTION
Add the dependency in two places:
1. `requirements.txt`: just the name of the library (it might be different from the one you see in the error message, e.g., you were missing `dateutil` but the name is actually `python-dateutil`.)
2. `src/BUILD`: in `convo_word_freq_diff`'s `deps`, add `requirement("LIB_NAME"),`